### PR TITLE
ci(node): do not run tests on node 18

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,18 +7,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18.x, 20.x]
-
     steps:
       - name: Checkout 🛬
         uses: actions/checkout@v4
       - name: Setup Node ⚙️
         uses: ./.github/actions/setup-node
-        with:
-          version: ${{ matrix.node-version }}
       - name: Build typescript 📦
         run: npm run build && find dist/index.js
       - name: Lint code 💅


### PR DESCRIPTION
## Proposed changes

In this PR we are removing running the node build and tests on version 18 since the runner for this action is node 20

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

